### PR TITLE
Add invested amount summary tile

### DIFF
--- a/planner/src/app/moneydisplay/moneydisplay.component.html
+++ b/planner/src/app/moneydisplay/moneydisplay.component.html
@@ -74,6 +74,13 @@
     </div>
   </div>
 
+  <div class="stats">
+    <div class="stat-item">
+      <h3>Invested Amount</h3>
+      <p>{{ investedAmount | currency:'EUR':'symbol':'1.0-0' }}</p>
+    </div>
+  </div>
+
   <div class="chart-container">
     <canvas baseChart
       [type]="lineChartType"

--- a/planner/src/app/moneydisplay/moneydisplay.component.sass
+++ b/planner/src/app/moneydisplay/moneydisplay.component.sass
@@ -98,3 +98,26 @@
   width: 100%
   height: 400px
   margin-top: 20px
+
+.stats
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))
+  gap: 20px
+  margin-bottom: 30px
+
+.stat-item
+  background: #f8f9fa
+  padding: 15px
+  border-radius: 8px
+  text-align: center
+
+  h3
+    margin: 0 0 10px 0
+    font-size: 1em
+    color: #666
+
+  p
+    margin: 0
+    font-size: 1.4em
+    font-weight: 500
+    color: #2c3e50

--- a/planner/src/app/moneydisplay/moneydisplay.component.ts
+++ b/planner/src/app/moneydisplay/moneydisplay.component.ts
@@ -23,6 +23,7 @@ export class MoneydisplayComponent {
   plans: Plan[] = [];
   events: FinancialEvent[] = [];
   nextPlanId = 1;
+  investedAmount = 0;
 
   constructor(private calculator: FinancialCalculatorService) {
     Chart.register(annotationPlugin);
@@ -173,6 +174,9 @@ export class MoneydisplayComponent {
     this.lineChartData.datasets[2].data = results.map(r => r.cashBalance);
     this.lineChartData.datasets[3].data = results.map(r => r.netInvestments);
     this.lineChartData.labels = results.map(r => "Year " + r.year);
+
+    this.investedAmount = this.totalMoney +
+      results.reduce((sum, r) => sum + r.netInvestments, 0);
 
     // Create new chart options with updated annotations
     this.lineChartOptions = {

--- a/planner/src/app/services/financial-calculator.service.spec.ts
+++ b/planner/src/app/services/financial-calculator.service.spec.ts
@@ -17,6 +17,7 @@ describe('FinancialCalculatorService', () => {
       monthlyExpenses: 0,
       interestRate: 0.05,
       plans: [],
+      events: [],
       years: 1
     };
 
@@ -39,6 +40,7 @@ describe('FinancialCalculatorService', () => {
         duration: 1,
         yearlyIncrease: 0
       }],
+      events: [],
       years: 1
     };
 
@@ -61,6 +63,7 @@ describe('FinancialCalculatorService', () => {
         startYear: 0,
         duration: 1
       }],
+      events: [],
       years: 1
     };
 
@@ -92,6 +95,7 @@ describe('FinancialCalculatorService', () => {
         startYear: 0,
         duration: 1
       }],
+      events: [],
       years: 1
     };
 
@@ -116,6 +120,7 @@ describe('FinancialCalculatorService', () => {
         duration: 2,
         yearlyIncrease: 10
       }],
+      events: [],
       years: 2
     };
 
@@ -138,6 +143,7 @@ describe('FinancialCalculatorService', () => {
         startYear: 0,
         duration: 1
       }],
+      events: [],
       years: 1
     };
 
@@ -170,6 +176,7 @@ describe('FinancialCalculatorService', () => {
           duration: 1
         }
       ],
+      events: [],
       years: 1
     };
 
@@ -187,6 +194,7 @@ describe('FinancialCalculatorService', () => {
       monthlyExpenses: 2000,
       interestRate: 0,
       plans: [],
+      events: [],
       years: 1
     };
 


### PR DESCRIPTION
## Summary
- show cumulative invested amount in Moneydisplay component
- add matching tile styles
- update financial calculator tests for new property

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e2a8f448324ba208847aea71875