### PR TITLE
feat: Implement PR previews with GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main  # or your default branch name
+  pull_request: {}
 
 permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write # Added this line
 
 
 concurrency:
@@ -17,6 +19,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    id: build_and_deploy_job # Add id here
     runs-on: ubuntu-latest
 
     steps:
@@ -37,14 +40,24 @@ jobs:
 
       - name: Build
         working-directory: planner
-        run: npm run build -- --base-href=/finsim/
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npm run build -- --base-href=/finsim/pr/${{ github.event.number }}/
+          else
+            npm run build -- --base-href=/finsim/
+          fi
         # Replace 'planner' with your repository name
 
 
       - name: Prepare deployment
         run: |
-          mkdir -p ./deploy
-          cp -r planner/dist/planner/browser/* ./deploy/
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            mkdir -p ./deploy/pr/${{ github.event.number }}
+            cp -r planner/dist/planner/browser/* ./deploy/pr/${{ github.event.number }}/
+          else
+            mkdir -p ./deploy
+            cp -r planner/dist/planner/browser/* ./deploy/
+          fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -54,3 +67,25 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  comment-pr-preview-link:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # Only run for PRs from the same repo
+    needs: build_and_deploy_job
+    steps:
+      - name: Comment PR Preview Link
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.issue.number;
+            const repoName = 'finsim'; // As per existing base-href
+            const previewUrl = `https://${{ github.repository_owner }}.github.io/${repoName}/pr/${prNumber}/`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `🚀 PR Preview available at: [${previewUrl}](${previewUrl})
+
+Action run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+            });


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to build and deploy PR previews to GitHub Pages.

Key changes:
- Modified the existing 'deploy.yml' workflow to trigger on 'pull_request' events.
- Adjusted the 'base-href' during the build step to correctly point to the PR-specific path (e.g., /finsim/pr/<PR_NUMBER>/).
- Updated deployment steps to place PR previews in a subdirectory named after the PR number within the deployment artifact.
- Added a new job, 'comment-pr-preview-link', which posts a comment on the PR with a direct link to the preview URL after successful deployment.
- Granted 'pull-requests: write' permission to the workflow to enable commenting on PRs.

This allows collaborators to easily review changes in a live environment before merging.