### PR TITLE
feat: Add life events functionality

### DIFF
--- a/planner/src/app/monte-carlo-simulation/monte-carlo-simulation.component.html
+++ b/planner/src/app/monte-carlo-simulation/monte-carlo-simulation.component.html
@@ -45,6 +45,36 @@
     </div>
   </div>
 
+  <div class="life-events-section">
+    <h2>Life Events</h2>
+    <div class="event-list" *ngIf="lifeEvents.length > 0">
+      <h3>Current Life Events:</h3>
+      <ul>
+        <li *ngFor="let event of lifeEvents; let i = index">
+          <span>{{ event.name }} (Year: {{ event.year }}, Cost: {{ event.cost | currency:'EUR':'symbol':'1.0-0' }})</span>
+          <button (click)="removeLifeEvent(i)" class="remove-event-btn">Remove</button>
+        </li>
+      </ul>
+    </div>
+
+    <div class="add-event-form">
+      <h3>Add New Life Event:</h3>
+      <div class="form-group">
+        <label for="eventName">Event Name:</label>
+        <input type="text" id="eventName" [(ngModel)]="newEventName" placeholder="e.g., Buy House">
+      </div>
+      <div class="form-group">
+        <label for="eventYear">Event Year:</label>
+        <input type="number" id="eventYear" [(ngModel)]="newEventYear" placeholder="e.g., 5">
+      </div>
+      <div class="form-group">
+        <label for="eventCost">Event Cost:</label>
+        <input type="number" id="eventCost" [(ngModel)]="newEventCost" placeholder="e.g., 50000">
+      </div>
+      <button (click)="onAddLifeEvent()" class="add-event-btn">Add Life Event</button>
+    </div>
+  </div>
+
   <div class="results-section" *ngIf="result">
     <div class="stats">
       <div class="stat-item">


### PR DESCRIPTION
This commit introduces a life events feature to the Monte Carlo simulation.

Key changes:
- Defined a `LifeEvent` interface with `name`, `year`, and `cost`.
- Updated `MonteCarloSimulationComponent` to manage an array of life events.
- Modified the simulation logic to account for the financial impact of life events, treating them as one-time expenses in the specified year.
- Added methods (`addLifeEvent`, `removeLifeEvent`, `onAddLifeEvent`) to the component for managing life events.
- Updated the component template (`monte-carlo-simulation.component.html`) to:
    - Display the list of current life events with their details.
    - Provide a "Remove" button for each life event.
    - Include a form to add new life events (name, year, cost).
- Pre-populated the life events list with two default events: "Buy a car" (Year 5, Cost €20,000) and "Buy a house" (Year 10, Cost €50,000).

The simulation now more accurately reflects potential real-world financial planning by incorporating these significant one-time expenses.