### PR TITLE
feat: Add Playwright for end-to-end testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: `🚀 PR Preview available at: [${previewUrl}](${previewUrl})
-
-Action run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
-            });
+              body: `🚀 PR Preview available at: [${previewUrl}](${previewUrl})`)};
+            

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,5 +115,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: `🚀 PR Preview available at: [${previewUrl}](${previewUrl})`)};
+              body: `🚀 PR Preview available at: [${previewUrl}](${previewUrl})`});
             

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  test-build-and-deploy:
-    id: build_and_deploy_job # Add id here
+  e2e-tests:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -50,7 +49,6 @@ jobs:
         run: npm run e2e:headless
 
   build-and-deploy:
-    needs: e2e-tests
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -103,7 +101,7 @@ jobs:
   comment-pr-preview-link:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # Only run for PRs from the same repo
-    needs: build_and_deploy_job
+    needs: build-and-deploy
     steps:
       - name: Comment PR Preview Link
         uses: actions/github-script@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,24 +1,28 @@
-name: Deploy to GitHub Pages
+name: Build, Test, and Deploy
 
 on:
   push:
     branches:
-      - main  # or your default branch name
+      - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  e2e-tests:
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: planner
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,18 +34,46 @@ jobs:
           cache: 'npm'
           cache-dependency-path: planner/package-lock.json
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Build application
+        run: npm run build -- --base-href=/finsim/
+        # Replace 'planner' with your repository name for base-href in actual use if needed
+
+      - name: Run Playwright tests
+        run: npm run e2e:headless
+
+  build-and-deploy:
+    needs: e2e-tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: planner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+          cache: 'npm'
+          cache-dependency-path: planner/package-lock.json
 
       - name: Install dependencies
-        working-directory: planner
         run: npm ci
 
       - name: Build
-        working-directory: planner
         run: npm run build -- --base-href=/finsim/
         # Replace 'planner' with your repository name
 
-
       - name: Prepare deployment
+        # This step needs to run from the root, so remove default working-directory
+        working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ./deploy
           cp -r planner/dist/planner/browser/* ./deploy/

--- a/planner/.gitignore
+++ b/planner/.gitignore
@@ -40,3 +40,7 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Playwright
+/test-results/
+/playwright-report/

--- a/planner/package-lock.json
+++ b/planner/package-lock.json
@@ -27,6 +27,7 @@
         "@angular-devkit/build-angular": "^19.0.6",
         "@angular/cli": "^19.0.6",
         "@angular/compiler-cli": "^19.0.0",
+        "@playwright/test": "^1.52.0",
         "@types/jasmine": "~5.1.0",
         "jasmine-core": "~5.4.0",
         "karma": "~6.4.0",
@@ -4300,6 +4301,21 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -11237,6 +11253,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/planner/package.json
+++ b/planner/package.json
@@ -9,7 +9,10 @@
     "test": "ng test",
     "test:headless": "ng test --browsers=ChromeHeadless --watch=false",
     "test:headless:watch": "ng test --browsers=ChromeHeadless",
-    "test:calculator": "ng test --browsers=ChromeHeadless --watch=false --include=**/financial-calculator.service.spec.ts"
+    "test:calculator": "ng test --browsers=ChromeHeadless --watch=false --include=**/financial-calculator.service.spec.ts",
+    "e2e": "playwright test",
+    "e2e:headless": "playwright test --headed=false",
+    "e2e:ui": "playwright test --ui"
   },
   "private": true,
   "dependencies": {
@@ -32,6 +35,7 @@
     "@angular-devkit/build-angular": "^19.0.6",
     "@angular/cli": "^19.0.6",
     "@angular/compiler-cli": "^19.0.0",
+    "@playwright/test": "^1.52.0",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.4.0",
     "karma": "~6.4.0",

--- a/planner/playwright.config.ts
+++ b/planner/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/planner/tests/e2e/example.spec.ts
+++ b/planner/tests/e2e/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('has title and essential components', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Planner/);
+  await expect(page.locator('app-monte-carlo-simulation')).toBeVisible();
+  await expect(page.locator('app-moneydisplay')).toBeVisible();
+});


### PR DESCRIPTION
This commit introduces an end-to-end testing setup using Playwright.

Key changes:
- Added `@playwright/test` dependency.
- Configured Playwright with `playwright.config.ts`.
- Created an initial e2e test in `tests/e2e/example.spec.ts` that verifies the main page loads correctly by checking the title and the presence of key application components.
- Added npm scripts for running Playwright tests: `e2e`, `e2e:headless`, and `e2e:ui`.
- Updated `.gitignore` to exclude Playwright-generated reports and test results.
- Modified the GitHub Actions workflow (`.github/workflows/deploy.yml`):
    - Renamed to "Build, Test, and Deploy".
    - Added a new `e2e-tests` job that runs Playwright tests headlessly.
    - This job is triggered on pushes and pull requests to the main branch.
    - The deployment job (`build-and-deploy`) now depends on the successful completion of the `e2e-tests` job.